### PR TITLE
Adds support for a simple ELF loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Configuration
 =============
 
 The bootloader expects a single configuration file to read information on the
-image and parmeters to boot.
+image and parameters to boot.
 
 The bootloader is configured via a single configuration file, and can boot either
  an ARM kernel image or an ELF unikernel (e.g.
@@ -56,7 +56,7 @@ The required elements in the configuration file differ depending on the type of
 image being loaded, examples for both are given below.
 
 It is an error specify both unikernel and kernel config parameters in the same
-configureation file.
+configuration file.
 
 ### Kernel
 To load a kernel, the bootloader requires that you provide the paths to the

--- a/README.md
+++ b/README.md
@@ -47,10 +47,23 @@ Configuration
 =============
 
 The bootloader expects a single configuration file to read information on the
-command line, kernel and device tree blob paths along with their SHA256
-checksum for validation.
+image and parmeters to boot.
 
-Example `/boot/armory-boot.conf` configuration file:
+The bootloader is configured via a single configuration file, and can boot either
+ an ARM kernel image or an ELF unikernel (e.g.
+[tamago-example](https://github.com/f-secure-foundry/tamago-example)).
+The required elements in the configuration file differ depending on the type of
+image being loaded, examples for both are given below.
+
+It is an error specify both unikernel and kernel config parameters in the same
+configureation file.
+
+### Kernel
+To load a kernel, the bootloader requires that you provide the paths to the
+kernel image and the Device Tree Blob file, along with their respective
+SHA256 hashes for validation, as well as the kernel command line.
+
+Example `/boot/armory-boot.conf` configuration file for loading a kernel:
 
 ```
 {
@@ -63,6 +76,24 @@ Example `/boot/armory-boot.conf` configuration file:
     "60d4fe465ef60042293f5723bf4a001d8e75f26e517af2b55e6efaef9c0db1f6"
   ],
   "cmdline": "console=ttymxc1,115200 root=/dev/mmcblk1p1 rootwait rw"
+}
+```
+
+### ELF Unikernel
+> :warning: this is currently experimental, and requires that the HW RNG is
+> not reinitialised.
+
+To load an ELF Unikernel, the bootloader only needs the path to the unikernel
+image file along with its SHA256 hash for validation.
+
+Example `/boot/armory-boot.conf` configuration file for loading an ELF unikernel:
+
+```
+{
+  "unikernel": [
+    "/boot/tamago-example",
+    "e6de9214249dd7989b4056372424e84b273ff4e5d2410fa12ac230ddaf22690a"
+  ]
 }
 ```
 

--- a/boot.go
+++ b/boot.go
@@ -9,6 +9,8 @@
 package main
 
 import (
+	"bytes"
+	"debug/elf"
 	"fmt"
 
 	"github.com/f-secure-foundry/tamago/arm"
@@ -21,7 +23,7 @@ import (
 func exec(kernel uint32, params uint32)
 func svc()
 
-func boot(kernel []byte, dtb []byte, cmdline string) {
+func bootKernel(kernel []byte, dtb []byte, cmdline string) {
 	dma.Init(dmaStart, dmaSize)
 	mem, _ := dma.Reserve(dmaSize, 0)
 
@@ -50,6 +52,60 @@ func boot(kernel []byte, dtb []byte, cmdline string) {
 		imx6.ARM.CacheDisable()
 
 		exec(image, params)
+	})
+
+	svc()
+}
+
+// bootELFUnikernel attempts to load the provided ELF image and jumps to it.
+//
+// This function implements a _very_ simple ELF loader which is suitable for
+// loading bare-metal ELF files like those produced by Tamago.
+func bootELFUnikernel(img []byte) {
+	dma.Init(dmaStart, dmaSize)
+	mem, _ := dma.Reserve(dmaSize, 0)
+
+	f, err := elf.NewFile(bytes.NewReader(img))
+	if err != nil {
+		panic(err.Error)
+	}
+
+	for idx, prg := range f.Progs {
+		if prg.Type == elf.PT_LOAD {
+			b := make([]byte, prg.Memsz)
+			_, err := prg.ReadAt(b[0:prg.Filesz], 0)
+			if err != nil {
+				panic(fmt.Sprintf("Failed to read LOAD section at idx %d: %q", idx, err))
+			}
+			offset := uint32(prg.Paddr) - mem
+			dma.Write(mem, b, int(offset))
+		}
+	}
+
+	entry := f.Entry
+
+	arm.ExceptionHandler(func(n int) {
+		if n != arm.SUPERVISOR {
+			panic("unhandled exception")
+		}
+
+		fmt.Printf("armory-boot: starting unikernel elf image@%x\n", entry)
+
+		usbarmory.LED("blue", false)
+		usbarmory.LED("white", false)
+
+		// TODO(al): There's some issue around the hw rng at the moment:
+		//           RNGB.Init() will hang waiting for the RNG to finish
+		//           reseeding.
+		// imx6.RNGB.Reset()
+
+		imx6.ARM.InterruptsDisable()
+		imx6.ARM.CacheFlushData()
+		imx6.ARM.CacheDisable()
+
+		// We can re-use the kernel exec even though we don't really need
+		// some of the functionality in there.
+		exec(uint32(entry), 0)
 	})
 
 	svc()

--- a/conf.go
+++ b/conf.go
@@ -19,7 +19,14 @@ const defaultConfigPath = "/boot/armory-boot.conf"
 
 var conf Config
 
+// Config tells the boot-loader what it should attempt to load and boot.
+//
+// The bootloader can load either a Linux kernel, or an ELF unikernel.
 type Config struct {
+	// Unikernel is the path to an ELF unikernel image.
+	Unikernel []string `json:"unikernel"`
+
+	// Kernel is the path to a Linux kernel image.
 	Kernel         []string `json:"kernel"`
 	DeviceTreeBlob []string `json:"dtb"`
 	CmdLine        string   `json:"cmdline"`
@@ -42,12 +49,28 @@ func (c *Config) Read(partition *Partition, configPath string) (err error) {
 		return
 	}
 
-	if len(conf.Kernel) != 2 {
-		return errors.New("invalid kernel parameter size")
+	ul, kl := len(conf.Unikernel), len(conf.Kernel)
+
+	isUnikernel, isKernel := ul > 0, kl > 0
+	if isUnikernel == isKernel {
+		return errors.New("must specify either unikernel or kernel")
 	}
 
-	if len(conf.DeviceTreeBlob) != 2 {
-		return errors.New("invalid kernel parameter size")
+	switch {
+	case isKernel:
+		if kl != 2 {
+			return errors.New("invalid kernel parameter size")
+		}
+
+		if len(conf.DeviceTreeBlob) != 2 {
+			return errors.New("invalid dtb parameter size")
+		}
+	case isUnikernel:
+		if ul != 2 {
+			return errors.New("invalid unikernel parameter size")
+		}
+	default:
+		panic("logic error: config is neither for kernel nor unikernel")
 	}
 
 	c.Print()


### PR DESCRIPTION
Towards #1 

There's an issue with the h/w RNG being reset and re-initialised, so some more work is needed, but modifying the `tamago/soc/imx6/rndb.go` file to remove the call to `RNGB.Init` with the following patch allows `tamago-example` to be successfully booted from the bootloader:

```diff
diff --git a/soc/imx6/rngb.go b/soc/imx6/rngb.go
index d575f1a..956c7e0 100644
--- a/soc/imx6/rngb.go
+++ b/soc/imx6/rngb.go
@@ -54,7 +54,7 @@ var getRandomDataFn func([]byte)
 //go:linkname initRNG runtime.initRNG
 func initRNG() {
        if Family == IMX6ULL && Native {
-               RNGB.Init()
+//             RNGB.Init()
                getRandomDataFn = RNGB.getRandomData
        } else {
                getRandomDataFn = getLCGData
```